### PR TITLE
ROS node multiple Arducams and read/write sensor register support

### DIFF
--- a/ROS/arducam_usb2_ros/CMakeLists.txt
+++ b/ROS/arducam_usb2_ros/CMakeLists.txt
@@ -9,6 +9,8 @@ project(arducam_usb2_ros)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   rospy
+  message_generation
+  std_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -52,11 +54,13 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
+ add_service_files(
+   FILES
+   WriteReg.srv
+   ReadReg.srv
 #   Service1.srv
-#   Service2.srv
-# )
+#   Service2.srv    
+ )
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -66,10 +70,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
+ generate_messages(
+   DEPENDENCIES
+   std_msgs  # Or other packages containing msgs
+ )
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##

--- a/ROS/arducam_usb2_ros/README.md
+++ b/ROS/arducam_usb2_ros/README.md
@@ -1,13 +1,29 @@
-# arducam_usb2_ros
-ArduCAM USB2 Shield ROS node
+# ArduCAM USB2 Shield ROS node
 
-Setup:
-1. run create_udev_rules.sh in scripts folder
-2. run 'chmod +x arducam_ros_node.py' command in src folder
+## Setup:
+1. Copy arducam_usb2_ros to your catkin workspace directory
+2. Run catkin_make
+3. Run setup.sh in arducam_usb2_ros folder
 
-Usage:
-1. Change "camera_config" argument in arducam_node.launch file to corresponding Arducam camera.
+## Usage:
+1. Change "camera_config" argument in arducam_node.launch file to your corresponding Arducam camera.
+3. Change "serial_number" argument in arducam_node.launch file to your corresponding Arducam's serial number in the form of XXXX-XXXX-XXXX-XXXX, leave it blank if there is only one camera.
 2. roslaunch arducam_usb2_ros arducam_node.launch
 
-Topic publish:
-/arducam/camera/image_raw
+## With default arducam_node.launch file,
+- ### Topic publish:
+cam0/arducam/camera/image_raw
+
+- ### Read value from sensor register:
+rosservice call cam0/arducam/read_reg *(register address)*
+
+Example, to obtain chip version:
+
+rosservice call cam0/arducam/read_reg 0
+
+- ### Write value to sensor register:
+rosservice call cam0/arducam/write_reg *(register address) (value)*
+
+Example, to adjust exposure on MT9N001:
+
+rosservice call cam0/arducam/write_reg 12306 100

--- a/ROS/arducam_usb2_ros/README.md
+++ b/ROS/arducam_usb2_ros/README.md
@@ -12,16 +12,16 @@
 
 ## From default arducam_node.launch file
 - ### Topic publish:
-cam0/arducam/camera/image_raw
+/cam0/arducam/camera/image_raw
 
 - ### Read value from sensor register:
-rosservice call cam0/arducam/read_reg *(register address)*
+rosservice call /cam0/arducam/read_reg *(register address)*
 
 Example, to obtain chip version:
-rosservice call cam0/arducam/read_reg 0
+rosservice call /cam0/arducam/read_reg 0
 
 - ### Write value to sensor register:
-rosservice call cam0/arducam/write_reg *(register address) (value)*
+rosservice call /cam0/arducam/write_reg *(register address) (value)*
 
 Example, to adjust exposure on MT9N001:
-rosservice call cam0/arducam/write_reg 12306 100
+rosservice call /cam0/arducam/write_reg 12306 100

--- a/ROS/arducam_usb2_ros/README.md
+++ b/ROS/arducam_usb2_ros/README.md
@@ -10,7 +10,7 @@
 3. Change "serial_number" argument in arducam_node.launch file to your corresponding Arducam's serial number in the form of XXXX-XXXX-XXXX-XXXX, leave it blank if there is only one camera.
 2. roslaunch arducam_usb2_ros arducam_node.launch
 
-## With default arducam_node.launch file,
+## From default arducam_node.launch file
 - ### Topic publish:
 cam0/arducam/camera/image_raw
 

--- a/ROS/arducam_usb2_ros/README.md
+++ b/ROS/arducam_usb2_ros/README.md
@@ -7,7 +7,7 @@
 
 ## Usage:
 1. Change "camera_config" argument in arducam_node.launch file to your corresponding Arducam camera.
-3. Change "serial_number" argument in arducam_node.launch file to your corresponding Arducam's serial number in the form of XXXX-XXXX-XXXX-XXXX, leave it blank if there is only one camera.
+3. Change "serial_number" argument in arducam_node.launch file to your corresponding Arducam's serial number in the form of XXXX-XXXX-XXXX, leave it blank if there is only one camera.
 2. roslaunch arducam_usb2_ros arducam_node.launch
 
 ## From default arducam_node.launch file

--- a/ROS/arducam_usb2_ros/README.md
+++ b/ROS/arducam_usb2_ros/README.md
@@ -18,12 +18,10 @@ cam0/arducam/camera/image_raw
 rosservice call cam0/arducam/read_reg *(register address)*
 
 Example, to obtain chip version:
-
 rosservice call cam0/arducam/read_reg 0
 
 - ### Write value to sensor register:
 rosservice call cam0/arducam/write_reg *(register address) (value)*
 
 Example, to adjust exposure on MT9N001:
-
 rosservice call cam0/arducam/write_reg 12306 100

--- a/ROS/arducam_usb2_ros/launch/arducam_node.launch
+++ b/ROS/arducam_usb2_ros/launch/arducam_node.launch
@@ -1,9 +1,13 @@
 <launch>
 
-    <arg name="camera_config" value="MT9N001_9MP.json" />
+    <group ns="cam0" clear_params="true">
+        <arg name="camera_config" value="MT9N001_9MP.json" /> <!-- Config file in JSON_Config_Files folder of your camera . -->
+        <arg name="serial_number" value="" /> <!-- Serial number of the camera in the form of "XXXX-XXXX-XXXX-XXXX", leave it blank "" if there is only one camera. -->
 
-    <node name="arducam_ros_node" pkg="arducam_usb2_ros" type="arducam_ros_node.py" output="screen">
-        <param name="config_file" value="$(find arducam_usb2_ros)/JSON_Config_Files/$(arg camera_config)" />
-    </node>
+        <node name="arducam_ros_node" pkg="arducam_usb2_ros" type="arducam_ros_node.py" output="screen">
+            <param name="config_file" value="$(find arducam_usb2_ros)/JSON_Config_Files/$(arg camera_config)" />
+            <param name="camera_serial" value="$(arg serial_number)" />
+        </node>
+    </group>
 
 </launch>

--- a/ROS/arducam_usb2_ros/launch/arducam_node.launch
+++ b/ROS/arducam_usb2_ros/launch/arducam_node.launch
@@ -2,7 +2,7 @@
 
     <group ns="cam0" clear_params="true">
         <arg name="camera_config" value="MT9N001_9MP.json" /> <!-- Config file in JSON_Config_Files folder of your camera . -->
-        <arg name="serial_number" value="" /> <!-- Serial number of the camera in the form of "XXXX-XXXX-XXXX-XXXX", leave it blank "" if there is only one camera. -->
+        <arg name="serial_number" value="" /> <!-- Serial number of the camera in the form of "XXXX-XXXX-XXXX", leave it blank "" if there is only one camera. -->
 
         <node name="arducam_ros_node" pkg="arducam_usb2_ros" type="arducam_ros_node.py" output="screen">
             <param name="config_file" value="$(find arducam_usb2_ros)/JSON_Config_Files/$(arg camera_config)" />

--- a/ROS/arducam_usb2_ros/package.xml
+++ b/ROS/arducam_usb2_ros/package.xml
@@ -7,13 +7,13 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="todo@todo.todo">TODO</maintainer>
+  <maintainer email="ehong@ntu.edu.sg">EH Ong</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>BSD</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
@@ -37,13 +37,13 @@
   <!--   <build_depend>roscpp</build_depend> -->
   <!--   <exec_depend>roscpp</exec_depend> -->
   <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+  <build_depend>message_generation</build_depend>
   <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <build_export_depend>message_generation</build_export_depend>
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <exec_depend>message_runtime</exec_depend>
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->

--- a/ROS/arducam_usb2_ros/setup.sh
+++ b/ROS/arducam_usb2_ros/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo cp `rospack find arducam_usb2_ros`/scripts/arducam.rules  /etc/udev/rules.d
+sudo service udev reload
+sudo service udev restart
+chmod +x src/arducam_ros_node.py
+

--- a/ROS/arducam_usb2_ros/srv/ReadReg.srv
+++ b/ROS/arducam_usb2_ros/srv/ReadReg.srv
@@ -1,0 +1,3 @@
+uint64 register
+---
+string return_value

--- a/ROS/arducam_usb2_ros/srv/WriteReg.srv
+++ b/ROS/arducam_usb2_ros/srv/WriteReg.srv
@@ -1,0 +1,4 @@
+uint64 register
+uint64 value
+---
+string return_value


### PR DESCRIPTION
1. Added service server to read/write sensor register for manual tweaking such as exposure, gain, etc.
2. Added serial number argument to initialize camera based on serial number which enables opening multiple cameras on one PC.