### PR TITLE
Update README.md

### DIFF
--- a/Windows/GUI/USBTest/README.md
+++ b/Windows/GUI/USBTest/README.md
@@ -2,7 +2,8 @@
 
 Windows demo code for the following cameras:
 
-- MT9V034 (0.36MP Global Shutter Camera)
+- MT9V034 (0.36MP Color Global Shutter Camera)
+- MT9V022 (0.3MP Mono Global Shutter Camera)
 - AR0134  (1.2MP Global Shutter Camera)
 - MT9N001 (9MP Color Rolling Shutter Camera)
 - MT9J001 (10MP Mono Rolling Shutter Camera)


### PR DESCRIPTION
Added the MT9V022 image sensor to the front of the read me because it is easier to purchase right now from vendors if you are in the US compared to some of the other image sensors that have been discontinued. The demo code does work for the MT9V022. It just needs slight tweaking (see resolved issues).